### PR TITLE
Move to centrally managed Issue form templates and GitHub Action workflows

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,28 +1,12 @@
-name: Stale
+name: Stale workflow
 
 on:
-  issues:
-    types: [reopened]
+  workflow_dispatch:
   schedule:
-    - cron: '30 1 * * *'
+    - cron: '45 11 * * *'
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
-    env:
-      ACTIONS_STEP_DEBUG: true
-    steps:
-      - uses: actions/stale@v4
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.'
-          stale-pr-message: 'This pull request has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.'
-          stale-issue-label: 'stale'
-          stale-pr-label: 'stale'
-          days-before-stale: 30
-          days-before-close: 5
-          exempt-issue-labels: 'pinned,pending-review,awaiting-changes,verified'
-          exempt-pr-labels: 'awaiting-approval,work-in-progress'
-          remove-stale-when-updated: true
-          close-issue-message: 'This issue has been automatically closed because it has not had recent activity. Thank you for your contributions.'
-          close-pr-message: 'This pull request has been automatically closed because it has not had recent activity. Thank you for your contributions.'
+    uses: homebridge/.github/.github/workflows/stale.yml@main
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## :recycle: Current situation

Currently the verified repo:

Defines repo specific workflow files
Defines a repo specific PR template

## :bulb: Proposed solution

This PR migrates all this files applicable to the centrally managed community health files located in the [.github](https://github.com/homebridge/.github) repo.

This has the following implications:
* PR template is now consistent across Homebridge Org repositories
* All applicable workflow files are now consistent across Homebridge Org repositories

## :gear: Release Notes

* Updated the PR template

## :heavy_plus_sign: Additional Information
*If applicable, provide additional context in this section.*

### Testing

--

### Reviewer Nudging

See our [.github](https://github.com/homebridge/.github) repo and GitHubs [Reusing workflows](https://docs.github.com/en/actions/learn-github-actions/reusing-workflows) documentation for more info.
You can demo the issue templates in the `.github` template.
