### PR TITLE
Bump action environment from Node12 to Node16

### DIFF
--- a/precheck/action.yml
+++ b/precheck/action.yml
@@ -14,7 +14,7 @@ outputs:
   comment-body:
     description: 'The id of the created comment'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'
 branding:
   icon: 'message-square'  


### PR DESCRIPTION
## :recycle: Current situation

🚨 Node 12 has an end of life on April 30, 2022.

GitHub Actions gives deprecation warning #487

The GitHub Actions workflow gives the following deprecation warning while running the action:

> Node.js 12 actions are deprecated. For more information see: github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12.



## :bulb: Proposed solution


This PR updates the default runtime to [node16](https://github.blog/changelog/2021-12-10-github-actions-github-hosted-runners-now-run-node-js-16-by-default/) rather then node12. 

This is supported on all Actions Runners v2.285.0 or later.


## :gear: Release Notes

Bump action environment from Node12 to Node16

## :heavy_plus_sign: Additional Information
Signed-off-by: Enes <ahmedenesturan@gmail.com>