### PR TITLE
Update the package name for python to python3

### DIFF
--- a/precheck/Dockerfile
+++ b/precheck/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:lts
 
-RUN apt-get update && apt-get install -y build-essential git python make g++
+RUN apt-get update && apt-get install -y build-essential git python3 make g++
 
 RUN mkdir -p /workspace /results
 


### PR DESCRIPTION
## :recycle: Current situation

Plugin checks are failing on the action "Check Plugin" due to a migration of the Python package preventing the `Dockerfile` from building.
See: https://github.com/homebridge/verified/actions/runs/5286333957/jobs/9565662798

## :bulb: Proposed solution

Specify `python3`.

## :gear: Release Notes

None required.

## :heavy_plus_sign: Additional Information

NA.

### Testing

Verified locally that this allows plugin checks to be executed.

NA.

### Reviewer Nudging

@bwp91, as you seem to have commented on verified plugins quite recently.
