### PR TITLE
Add homebridge-tuya-ir-remote

### DIFF
--- a/verified-plugins.json
+++ b/verified-plugins.json
@@ -477,6 +477,7 @@
   "homebridge-ttlock",
   "homebridge-tuya",
   "homebridge-tuya-ir",
+  "homebridge-tuya-ir-remote",
   "homebridge-tuya-platform",
   "homebridge-tuya-platform-talrhvfork",
   "homebridge-twinkly-plus",


### PR DESCRIPTION
## Plugin Submission

**Plugin Name:** homebridge-tuya-ir-remote  
**npm:** https://www.npmjs.com/package/homebridge-tuya-ir-remote  
**GitHub:** https://github.com/egphp/homebridge-tuya-ir-remote

### Description
Homebridge plugin for Tuya IR blasters - Control AC, TV, and Apple TV via IR commands through Tuya Cloud API.

### Features
- Air Conditioner control (power, temperature, mode, fan speed)
- TV control with iOS Control Center remote
- Apple TV control with iOS Control Center remote
- Multi-room support
- Homebridge Config UI X support

### Checklist
- [x] Plugin published on npm
- [x] Open source on GitHub
- [x] Has config.schema.json
- [x] Has README with installation and configuration instructions
- [x] Written in TypeScript
- [x] Uses Apache-2.0 license