### PR TITLE
Add homebridge-atomberg-fan-v2

### DIFF
--- a/verified-plugins.json
+++ b/verified-plugins.json
@@ -104,6 +104,7 @@
   "homebridge-arduino-esp-platform",
   "homebridge-argo",
   "homebridge-atomberg-fan",
+  "homebridge-atomberg-fan-v2",
   "homebridge-automower",
   "homebridge-automower-platform",
   "homebridge-aux-cloud",


### PR DESCRIPTION
## Plugin: `homebridge-atomberg-fan-v2`

- **npm**: https://www.npmjs.com/package/homebridge-atomberg-fan-v2
- **GitHub**: https://github.com/dhananjaysathe/homebridge-atomberg-fan-v2
- **License**: Apache-2.0

Maintained fork of the already-verified [`homebridge-atomberg-fan`](https://github.com/Sangwan5688/homebridge-atomberg-fan), with Homebridge v2.0 compatibility, the 6th (Boost) fan speed, working LED / brightness / colour-temperature control, hardened UDP state sync, debounce + throttle, and offline detection. The upstream repo has been stale since May 2024 and has open issues covering both v2.0 compatibility ([#5](https://github.com/shadow5688/homebridge-atomberg-fan/issues/5)) and Boost mode ([#1](https://github.com/shadow5688/homebridge-atomberg-fan/issues/1)); this fork ships both fixes.

### Verified-plugin checklist

- [x] Published on npm with the `homebridge-` prefix
- [x] `homebridge` and `homebridge-plugin` in `package.json` keywords
- [x] Valid `config.schema.json` (renders in Homebridge UI)
- [x] Dynamic platform plugin (uses `api.registerPlatform`)
- [x] Apache-2.0 open-source licence
- [x] Public GitHub repo with README, CHANGELOG, LICENSE
- [x] Tested on Homebridge v1.11.x and the v2.0 beta line against a real Atomberg fleet
- [x] New platform alias (`AtombergFanV2`) so it installs cleanly alongside the original plugin during migration

Happy to address any review feedback. Thanks for maintaining this list.