### PR TITLE
Add homebridge-kdk-plugin

### DIFF
--- a/verified-plugins.json
+++ b/verified-plugins.json
@@ -290,6 +290,7 @@
   "homebridge-juicebox",
   "homebridge-kasa-hub",
   "homebridge-kasa-python",
+  "homebridge-kdk-plugin",
   "homebridge-keylights",
   "homebridge-kiwigrid",
   "homebridge-klereo-connect",


### PR DESCRIPTION
## Add homebridge-kdk-plugin

Adds `homebridge-kdk-plugin` to the verified plugins list.

### Plugin details

- **npm**: https://www.npmjs.com/package/homebridge-kdk-plugin
- **GitHub**: https://github.com/sinwe/homebridge-kdk-plugin
- **Description**: Local control of KDK/Panasonic WiFi ceiling fans via ECHONET Lite (UDP port 3610) — no cloud dependency

### Features

- Fan on/off, speed (10 levels), rotation direction
- Light on/off, brightness (1–100%), colour temperature (warm–cool)
- Night mode (3 brightness levels)
- Auto-discovery via SSDP broadcast
- Periodic polling to sync state with physical remote changes

### Checklist

- [x] Published to npm with `homebridge-plugin` keyword
- [x] `config.schema.json` present
- [x] README with full configuration documentation
- [x] Homebridge 2.x compatible (`homebridge >= 1.3.0` peer dependency, Node >= 18)
- [x] Unit tests with CI (GitHub Actions)
- [x] Open source (MIT)
- [x] Actively maintained