### PR TITLE
Add homebridge-lg-thinqconnect-ac to verified plugins

### DIFF
--- a/verified-plugins.json
+++ b/verified-plugins.json
@@ -309,6 +309,7 @@
   "homebridge-levoit-humidifiers",
   "homebridge-lg-enervu",
   "homebridge-lg-thinq",
+  "homebridge-lg-thinqconnect-ac",
   "homebridge-lgwebos-tv",
   "homebridge-lifx-plugin",
   "homebridge-lighthouse",


### PR DESCRIPTION
## :recycle: Current situation

There is no verified Homebridge plugin for LG air conditioners that uses the new official LG ThinQ Connect API. The existing `homebridge-lg-thinq-ac` plugin uses a reverse-engineered OAuth flow, which is a fundamentally different integration.

## :bulb: Proposed solution

Add `homebridge-lg-thinqconnect-ac` to the verified plugins list.

**npm:** https://www.npmjs.com/package/homebridge-lg-thinqconnect-ac  
**GitHub:** https://github.com/cosmo84/homebridge-lg-thinq-ac

This plugin integrates LG ThinQ air conditioners via the official LG ThinQ Connect API (connect-pat.lgthinq.com), using a Personal Access Token issued directly by LG. It is a dynamic platform plugin with no native dependencies, supporting Homebridge v1 and v2.

Supported features: power on/off, mode selection (Cool/Heat/Auto), target temperature, current temperature, fan speed, vertical swing.

## :gear: Release Notes

Users can search for `homebridge-lg-thinqconnect-ac` in the Homebridge UI and install it directly. After obtaining a Personal Access Token from connect-pat.lgthinq.com, they enter it in the plugin settings along with their two-letter country code.

## :heavy_plus_sign: Additional Information

- No native dependencies (pure HTTP polling via axios, no MQTT/aws-crt)
- Supports Node.js v22 and v24
- Supports all LG ThinQ regions (Europe, Americas, Asia/Pacific)
- `config.schema.json` present for Homebridge Settings GUI
- GitHub Issues enabled

### Testing

Tested on a live Homebridge v2 Docker instance with real LG ThinQ air conditioners. Commands from HomeKit reach the devices, and state changes in the LG ThinQ app are reflected in HomeKit within 60 seconds.

### Reviewer Nudging

Start with the README for an overview, then `config.schema.json` for the settings GUI, and `src/api.ts` for the LG ThinQ Connect API integration.
