### PR TITLE
ci: enable Dependabot for weekly updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+- package-ecosystem: "npm"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  open-pull-requests-limit: 5


### PR DESCRIPTION
Adds `.github/dependabot.yml` so GitHub automatically opens PRs for outdated dependencies on a weekly cadence. Covers both the primary package ecosystem and GitHub Actions workflows.

The PR limit is set to 5 to avoid noise. Feel free to adjust or drop either ecosystem.